### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,8 @@ readme = "README.md"
 documentation = "https://docs.rs/ammonia/"
 repository = "https://github.com/notriddle/ammonia"
 
-[features]
-unstable = [ "html5ever/unstable", "tendril/unstable" ]
-
 [dependencies]
-html5ever = "0.18"
+html5ever = "0.19"
 maplit = "0.1"
-tendril = "0.3"
+tendril = "0.4"
 url = "1.4"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ However, it takes about fifty times longer to sanitize an HTML string using
 Bleach than it does using Ammonia.
 
     $ cd benchmarks
-    $ cargo run --release --features unstable
+    $ cargo run --release
         Running `target/release/ammonia_bench`
     56829 nanoseconds to clean up the intro to the Ammonia docs.
     $ python3 bleach_bench.py

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,9 +3,6 @@ name = "ammonia_bench"
 version = "0.0.1"
 license = "WTFPL"
 
-[features]
-unstable = [ "ammonia/unstable" ]
-
 [dependencies]
 ammonia = { path = "../" }
 time = "0.1"


### PR DESCRIPTION
Since html5ever and tendril dropped their unstable feature, I also
removed our unstable feature as it is now useless.