### PR TITLE
Always keep cleaned elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Breaking change: The `Ammonia` struct now uses the builder pattern for better forward compatibility
 * Added support for reading the input from a stream
+* Breaking change: `keep_cleaned_elements` is changed from being an off-by-default option to the only supported behavior
 
 # 0.7.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,6 @@ lazy_static! {
 ///                `<img width="" height="" src="" alt="">`
 ///  * URL schemes in links and images: `http`, `https`, `mailto`
 ///  * Relative URLs are not allowed, to prevent cross-site request forgery.
-///  * Elements with invalid attributes are completely removed,
-///    to avoid confusion about what is and is not allowed.
 pub fn clean(src: &str) -> String {
     AMMONIA.clean(src)
 }


### PR DESCRIPTION
`keep_cleaned_elements` was added by users who were dissatisfied by how Ammonia behaved differently than other sanitizers (particularly the one used by GitHub). In practice, it seems like everybody turns it on, or doesn't care.

So, why do we have the other option again?