### PR TITLE
Ensure that version numbers are in sync with crate version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 rust:
  - nightly
  - beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ammonia"
-version = "0.7.0" # remember to update html_root_url
+version = "0.7.0"
 authors = ["Michael Howell <michael@notriddle.com>"]
 description = "HTML Sanitization"
 keywords = [ "sanitization", "html", "security", "xss" ]
@@ -16,3 +16,6 @@ maplit = "0.1"
 tendril = "0.4"
 url = "1.5"
 lazy_static = "0.2"
+
+[dev-dependencies]
+version-sync = "0.3"

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate version_sync;
+
+#[test]
+fn test_readme_deps() {
+    assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
This PR adds an integration tests that uses my [version-sync][1] crate to detect if the version number in the `html_root_url` is ever out of sync with the crate version.

I hope you find this useful :-) It'll also check if TOML code in `README.md` mentions `ammonia` and uses an outdated version number.

[1]: https://crates.io/crates/version-sync