### PR TITLE
Add id_prefix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ pub fn clean(src: &str) -> String {
 /// [`generic_attributes`]: #method.generic_attributes
 /// [`link_rel`]: #method.link_rel
 /// [`allowed_classes`]: #method.allowed_classes
+/// [`id_prefix`]: #method.id_prefix
 #[derive(Debug)]
 pub struct Builder<'a> {
     tags: HashSet<&'a str>,
@@ -201,6 +202,7 @@ pub struct Builder<'a> {
     link_rel: Option<&'a str>,
     allowed_classes: HashMap<&'a str, HashSet<&'a str>>,
     strip_comments: bool,
+    id_prefix: Option<&'a str>,
 }
 
 impl<'a> Default for Builder<'a> {
@@ -293,6 +295,7 @@ impl<'a> Default for Builder<'a> {
             link_rel: Some("noopener noreferrer"),
             allowed_classes: allowed_classes,
             strip_comments: true,
+            id_prefix: None,
         }
     }
 }
@@ -600,6 +603,36 @@ impl<'a> Builder<'a> {
         self
     }
 
+    /// Prefixes all "id" attribute values with a given string.  Note that the tag and
+    /// attribute themselves must still be whitelisted.
+    ///
+    /// # Examples
+    ///
+    ///     #[macro_use]
+    ///     extern crate maplit;
+    ///     # extern crate ammonia;
+    ///
+    ///     use ammonia::Builder;
+    ///
+    ///     # fn main() {
+    ///     let attributes = hashset!["id"];
+    ///     let a = Builder::new()
+    ///         .generic_attributes(attributes)
+    ///         .id_prefix(Some("safe-"))
+    ///         .clean("<b id=42>")
+    ///         .to_string();
+    ///     assert_eq!(a, "<b id=\"safe-42\"></b>");
+    ///     # }
+
+    ///
+    /// # Defaults
+    ///
+    /// `None`
+    pub fn id_prefix(&mut self, value: Option<&'a str>) -> &mut Self {
+        self.id_prefix = value;
+        self
+    }
+
     /// Constructs a [`Builder`] instance configured with the [default options].
     ///
     /// # Examples
@@ -678,6 +711,8 @@ impl<'a> Builder<'a> {
         let mut stack = Vec::new();
         let link_rel = self.link_rel
             .map(|link_rel| format_tendril!("{}", link_rel));
+        let id_prefix = self.id_prefix
+            .map(|id_prefix| format_tendril!("{}", id_prefix));
         if link_rel.is_some() {
             assert!(self.generic_attributes.get("rel").is_none());
             assert!(
@@ -718,7 +753,7 @@ impl<'a> Builder<'a> {
                 .upgrade().expect("a node's parent will be pointed to by its parent (or the root pointer), and will not be dropped");
             let pass = self.clean_child(&mut node);
             if pass {
-                self.adjust_node_attributes(&mut node, &link_rel, &url_base);
+                self.adjust_node_attributes(&mut node, &link_rel, &url_base, &id_prefix);
                 dom.append(&parent.clone(), NodeOrText::AppendNode(node.clone()));
             } else {
                 for sub in node.children.borrow_mut().iter_mut() {
@@ -797,6 +832,7 @@ impl<'a> Builder<'a> {
         child: &mut Handle,
         link_rel: &Option<StrTendril>,
         url_base: &Option<Url>,
+        id_prefix: &Option<StrTendril>,
     ) {
         if let NodeData::Element {
             ref name,
@@ -810,6 +846,13 @@ impl<'a> Builder<'a> {
                         name: QualName::new(None, ns!(), local_name!("rel")),
                         value: link_rel.clone(),
                     })
+                }
+            }
+            if let Some(ref id_prefix) = *id_prefix {
+                for attr in &mut *attrs.borrow_mut() {
+                    if &attr.name.local == "id" {
+                        attr.value = format_tendril!("{}{}", id_prefix, attr.value);
+                    }
                 }
             }
             if let Some(ref base) = *url_base {
@@ -1502,5 +1545,13 @@ mod test {
     fn require_sync_and_send() {
         require_sync(Builder::new());
         require_send(Builder::new());
+    }
+    #[test]
+    fn id_prefixed() {
+        let fragment = "<a id=\"hello\"></a><b id=\"hello\"></a>";
+        let result = String::from(Builder::new().tag_attributes(hashmap![
+            "a" => hashset!["id"],
+        ]).id_prefix(Some("prefix-")).clean(fragment));
+        assert_eq!(result.to_string(), "<a id=\"prefix-hello\" rel=\"noopener noreferrer\"></a><b></b>");
     }
 }


### PR DESCRIPTION
We may want to keep `id`s from an untrusted source. One way to do this without worrying about name collisions is to prefix the IDs with some known string, effectively namespacing it. (e.g. we do this with anchor IDs at GitHub, prepending `"user-content-"`.)

This spike came up while thinking of solutions to https://github.com/rust-lang/crates.io/issues/1037, where we're trying to get anchor visiting working on crates.io. Currently we generate anchors from Markdown with the prefix, but if we were to allow those through at the sanitization stage, anchors directly entered by users as inline HTML still need to be made safe.