### PR TITLE
UrlRelative::Custom should only apply to relative URLs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1172,7 +1172,7 @@ impl<'a> Builder<'a> {
                 let mut drop_attrs = Vec::new();
                 let mut attrs = attrs.borrow_mut();
                 for (i, attr) in attrs.iter_mut().enumerate() {
-                    if is_url_attr(&*name.local, &*attr.name.local) {
+                    if is_url_attr(&*name.local, &*attr.name.local) && is_url_relative(&*attr.value) {
                         let new_value = evaluate.evaluate(&*attr.value)
                             .as_ref()
                             .map(Cow::as_ref)
@@ -1227,6 +1227,10 @@ impl<'a> Builder<'a> {
 /// Given an element name and attribute name, determine if the given attribute contains a URL.
 fn is_url_attr(element: &str, attr: &str) -> bool {
     attr == "href" || attr == "src" || (element == "object" && attr == "data")
+}
+
+fn is_url_relative(url: &str) -> bool {
+    matches!(Url::parse(url), Err(url::ParseError::RelativeUrlWithoutBase))
 }
 
 /// Policy for [relative URLs], that is, URLs that do not specify the scheme in full.
@@ -1815,7 +1819,7 @@ mod test {
             .url_relative(UrlRelative::Custom(Box::new(evaluate)))
             .clean("<a href=\"https://www.google.com/\">google</a>")
             .to_string();
-        assert_eq!(a, "<a href=\"https://www.google.com/\">google</a>");
+        assert_eq!(a, "<a href=\"https://www.google.com/\" rel=\"noopener noreferrer\">google</a>");
     }
     #[test]
     fn clean_children_of_bad_element() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1806,6 +1806,18 @@ mod test {
         assert_eq!(a, "<a rel=\"noopener noreferrer\">banned</a><a rel=\"noopener noreferrer\" title=\"test\">banned</a><a title=\"test\" rel=\"noopener noreferrer\">banned</a>");
     }
     #[test]
+    fn remove_relative_url_evaluate_c() {
+        // Don't run on absolute URLs.
+        fn evaluate(_: &str) -> Option<Cow<str>> {
+            return Some(Cow::Owned(String::from("invalid")));
+        }
+        let a = Builder::new()
+            .url_relative(UrlRelative::Custom(Box::new(evaluate)))
+            .clean("<a href=\"https://www.google.com/\">google</a>")
+            .to_string();
+        assert_eq!(a, "<a href=\"https://www.google.com/\">google</a>");
+    }
+    #[test]
     fn clean_children_of_bad_element() {
         let fragment = "<bad><evil>a</evil>b</bad>";
         let result = Builder::new().clean(fragment);


### PR DESCRIPTION
This doc comment suggests the PR title is already true:

https://github.com/notriddle/ammonia/blob/2a7ee33ce4897343907076a5bd6aeb149b93785e/src/lib.rs#L1290

The attached test case demonstrates otherwise. Will have a fix in this PR momentarily.