### PR TITLE
Drop src lifetime from Builder::clean

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -974,7 +974,7 @@ impl<'a> Builder<'a> {
     ///     # Ok(())
     ///     # }
     ///     # fn main() { do_main().unwrap() }
-    pub fn clean(&self, src: &'a str) -> Document {
+    pub fn clean(&self, src: &str) -> Document {
         let parser = Self::make_parser();
         let dom = parser.one(src);
         self.clean_dom(dom)


### PR DESCRIPTION
I haven't been able to write some code that didn't compile before, but the lifetime there doesn't look right.