### PR TITLE
Remove html_root_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want that, use a markup processor before running the sanitizer, like [pul
 Installation
 -----------
 
-To use `ammonia`, add this to your `[dependencies]` section:
+To use `ammonia`, add it to your project's `Cargo.toml` file:
 
 ```toml
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ If you want that, use a markup processor before running the sanitizer, like [pul
 [pulldown-cmark]: https://github.com/google/pulldown-cmark
 
 
+Installation
+-----------
+
+To use `ammonia`, add this to your `[dependencies]` section:
+
+```toml
+[dependencies]
+ammonia = "1.0.0-rc3"
+```
+
+
 Changes
 -----------
 Please see the [CHANGELOG](CHANGELOG.md) for a release history.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/ammonia/1.0.0-rc3")]
-
 // Copyright (C) Michael Howell and others
 // this library is released under the same terms as Rust itself.
 

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -5,8 +5,3 @@ extern crate version_sync;
 fn test_readme_deps() {
     assert_markdown_deps_updated!("README.md");
 }
-
-#[test]
-fn test_html_root_url() {
-    assert_html_root_url_updated!("src/lib.rs");
-}


### PR DESCRIPTION
`html_root_url` is no longer needed: https://github.com/rust-lang-nursery/api-guidelines/commit/5c457dfa5340fd3ba2ede0ca6d5896c48d1e7d49.

I have added an `Installation` section to `README.md`.