### PR TITLE
Add clean_content_tags()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2056,8 +2056,8 @@ mod test {
     fn clean_removed_default_tag() {
         let fragment = "<em>This is</em><script><a>Hello!</a></script><p>still here!</p>";
         let result = String::from(Builder::new()
-            .rm_tags(std::iter::once("a"))
-            .rm_tag_attributes("a", ::std::iter::once("href").chain(::std::iter::once("hreflang")))
+            .rm_tags(["a"].into_iter().cloned())
+            .rm_tag_attributes("a", ["href", "hreflang"].into_iter().cloned())
             .clean_content_tags(hashset!["script"])
             .clean(fragment));
         assert_eq!(result.to_string(), "<em>This is</em><p>still here!</p>");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2053,6 +2053,16 @@ mod test {
         assert_eq!(result.to_string(), "<em>This is</em><p>still here!</p>");
     }
     #[test]
+    fn clean_removed_default_tag() {
+        let fragment = "<em>This is</em><script><a>Hello!</a></script><p>still here!</p>";
+        let result = String::from(Builder::new()
+            .rm_tags(std::iter::once("a"))
+            .rm_tag_attributes("a", ::std::iter::once("href").chain(::std::iter::once("hreflang")))
+            .clean_content_tags(hashset!["script"])
+            .clean(fragment));
+        assert_eq!(result.to_string(), "<em>This is</em><p>still here!</p>");
+    }
+    #[test]
     #[should_panic]
     fn panic_on_clean_content_tag_attribute() {
         Builder::new()


### PR DESCRIPTION
Here's a basic implementation. I'm not completely sure how it should interact with the whitelist:

1. If a tag is in the blacklist that takes precedence, and the whitelist is ignored for that tag. (currently implemented)
2. If a tag is in both blacklist and whitelist then panic. (annoying to use with default options but explicit)
3. When a tag is added to the blacklist, it's automatically removed from the whitelist. (adds complexity and doesn't work well with `rm_clean_content_tags`, but is consistent)

Also I think defaulting to `clean_content_tags(["script", "style"])` is a good idea, but I know defaults are hard to change.

Closes #89