### PR TITLE
Adding `action`, `formaction` and `ping` to `is_url_attr`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1437,7 +1437,12 @@ impl<'a> Builder<'a> {
 
 /// Given an element name and attribute name, determine if the given attribute contains a URL.
 fn is_url_attr(element: &str, attr: &str) -> bool {
-    attr == "href" || attr == "src" || (element == "object" && attr == "data")
+    attr == "href" || attr == "src"
+    || (element == "form" && attr == "action")
+    || (element == "object" && attr == "data")
+    || ((element == "button" || element == "input") && attr == "formaction")
+    || (element == "a" && attr == "ping")
+    || (element == "video" && attr == "poster")
 }
 
 fn is_url_relative(url: &str) -> bool {


### PR DESCRIPTION
The `is_url_attr` function is used to decide whether elements need their
URLs filtered to comply users that want all links to remain on-origin.
This patch adds missing the attributes (`action` for `<form>`,
`formaction` for `<input>` and `<button>` and `ping` for `<a>`).

I have used the (non-normative) reference in the HTML spec to ensure
comprehensivenes:
https://html.spec.whatwg.org/multipage/indices.html#attributes-3