### PR TITLE
Release 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: rust
 cache: cargo
 rust:
- - nightly
  - beta
  - stable
+ - 1.24
 
 branches:
  only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: cargo
 rust:
  - beta
  - stable
- - 1.24
+ - 1.24.0
 
 branches:
  only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 *
 
+# 1.2.0
+
+* Recognize `action`, `formaction` and `ping` as [URL attributes](https://html.spec.whatwg.org/multipage/indices.html#attributes-3) for scheme and origin filtering
+* Add [`Builder::url_filter_map`] which allows URLs, both relative and absolute, to be pre-filtered
+
+[`Builder::url_filter_map`]: https://docs.rs/ammonia/1.1/ammonia/struct.Builder.html#method.url_filter_map
+
 # 1.1.0
 
 * Add [`Builder::clean_content_tags`] which allows elements to be removed entirely instead of just having the tags removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 # 1.2.0
 
-* Recognize `action`, `formaction` and `ping` as [URL attributes](https://html.spec.whatwg.org/multipage/indices.html#attributes-3) for scheme and origin filtering
+* Recognize `action`, `formaction` and `ping` as [URL attributes] for scheme and origin filtering
 * Add [`Builder::url_filter_map`] which allows URLs, both relative and absolute, to be pre-filtered
 
+[URL attributes]: https://html.spec.whatwg.org/multipage/indices.html#attributes-3
 [`Builder::url_filter_map`]: https://docs.rs/ammonia/1.1/ammonia/struct.Builder.html#method.url_filter_map
 
 # 1.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ammonia"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Michael Howell <michael@notriddle.com>"]
 description = "HTML Sanitization"
 keywords = [ "sanitization", "html", "security", "xss" ]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To use `ammonia`, add it to your project's `Cargo.toml` file:
 
 ```toml
 [dependencies]
-ammonia = "1.1.0"
+ammonia = "1.2.0"
 ```
 
 


### PR DESCRIPTION
# 1.2.0

* Recognize `action`, `formaction` and `ping` as [URL attributes](https://html.spec.whatwg.org/multipage/indices.html#attributes-3) for scheme and origin filtering
* Add [`Builder::url_filter_map`] which allows URLs, both relative and absolute, to be pre-filtered

[`Builder::url_filter_map`]: https://docs.rs/ammonia/1.1/ammonia/struct.Builder.html#method.url_filter_map