### PR TITLE
Mention Rust 1.24.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ HTML Sanitization
 
 [![Build Status](https://travis-ci.org/notriddle/ammonia.svg?branch=master)](https://travis-ci.org/notriddle/ammonia)
 [![Crates.IO](https://img.shields.io/crates/v/ammonia.svg)](https://crates.rs/crates/ammonia)
-![Requires rustc 1.24.0](https://img.shields.io/badge/rustc-1.24.0+-yellow.svg)
+![Requires rustc 1.24.0](https://img.shields.io/badge/rustc-1.24.0+-green.svg)
 
 Chat: [Gitter], [Matrix]
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ HTML Sanitization
 
 [![Build Status](https://travis-ci.org/notriddle/ammonia.svg?branch=master)](https://travis-ci.org/notriddle/ammonia)
 [![Crates.IO](https://img.shields.io/crates/v/ammonia.svg)](https://crates.rs/crates/ammonia)
+![Requires rustc 1.24.0](https://img.shields.io/badge/rustc-1.24.0+-yellow.svg)
 
 Chat: [Gitter], [Matrix]
 


### PR DESCRIPTION
This is pinned in travis.yml, so we should be able to
guarantee long-term support for that old compiler.