### PR TITLE
Use better defaults by cleaning content of script and style tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ lazy_static! {
 ///
 /// # Examples
 ///
-///     assert_eq!(ammonia::clean("<script>XSS</script>"), "XSS")
+///     assert_eq!(ammonia::clean("XSS<script>attack</script>"), "XSS")
 pub fn clean(src: &str) -> String {
     AMMONIA.clean(src).to_string()
 }
@@ -263,7 +263,9 @@ impl<'a> Default for Builder<'a> {
             "strike", "strong", "sub", "summary", "sup", "table", "tbody",
             "td", "th", "thead", "time", "tr", "tt", "u", "ul", "var", "wbr"
         ];
-        let clean_content_tags = hashset![];
+        let clean_content_tags = hashset![
+            "script", "style"
+        ];
         let generic_attributes = hashset![
             "lang", "title"
         ];
@@ -1602,7 +1604,7 @@ impl Document {
     ///
     ///     use ammonia::Builder;
     ///
-    ///     let input = "Some <style>HTML here";
+    ///     let input = "Some <style></style>HTML here";
     ///     let output = "Some HTML here";
     ///
     ///     let document = Builder::new()
@@ -1632,7 +1634,7 @@ impl Document {
     ///
     ///     use ammonia::Builder;
     ///
-    ///     let input = "Some <style>HTML here";
+    ///     let input = "Some <style></style>HTML here";
     ///     let expected = b"Some HTML here";
     ///
     ///     let document = Builder::new()
@@ -1744,7 +1746,7 @@ mod test {
     fn remove_script() {
         let fragment = "an <script>evil()</script> example";
         let result = clean(fragment);
-        assert_eq!(result, "an evil() example");
+        assert_eq!(result, "an  example");
     }
     #[test]
     fn ignore_link() {
@@ -2148,7 +2150,7 @@ mod test {
         let fragment = b"an <script>evil()</script> example";
         let result = Builder::new().clean_from_reader(&fragment[..]);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().to_string(), "an evil() example");
+        assert_eq!(result.unwrap().to_string(), "an  example");
     }
     #[test]
     fn reader_non_utf8() {


### PR DESCRIPTION
Hi,
I would like to propose the inclusion of the `script` and `style` tags to the `clean_content_tags` in the default configuration.

I think that the most common usage would be better covered with this change. Personally, I don't see the point of cleaning this HTML code:
```html
<style>h1 {font-size: 24pt}</style>
<h1>My Page</h1>
<p>My content...</p>
<script>console.log('page loaded')</script>
```

into this:
```html
h1 {font-size: 24pt}
<h1>My Page</h1>
<p>My content...</p>
console.log('page loaded')
```

Maybe there is some use-case for this but my guess is that it would be a really rare occurrence.

The common expectation would be to receive this result:
```html
<h1>My Page</h1>
<p>My content...</p>
```

and while I know that it's not so difficult to use a custom configuration to achieve this result, that would make the very quick `ammonia::clean` call almost useless and if I cared about having a cached static instance of ammonia::Builder I would also need to include lazy_static in my direct set of dependencies.