### PR TITLE
Add a way to specify approved values of attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1389,7 +1389,10 @@ impl<'a> Builder<'a> {
                         self.tag_attribute_values
                             .get(&*name.local)
                             .and_then(|tav| tav.get(&*attr.name.local))
-                            .map(|vs| vs.iter().any(|v| v.to_lowercase() == attr.value.to_lowercase())) ==
+                            .map(|vs| {
+                                let attr_val = attr.value.to_lowercase();
+                                vs.iter().any(|v| v.to_lowercase() == attr_val)
+                            }) ==
                             Some(true);
                     if !whitelisted {
                         // If the class attribute is not whitelisted,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1389,7 +1389,7 @@ impl<'a> Builder<'a> {
                         self.tag_attribute_values
                             .get(&*name.local)
                             .and_then(|tav| tav.get(&*attr.name.local))
-                            .map(|v| v.contains(&*attr.value)) ==
+                            .map(|vs| vs.iter().any(|v| v.to_lowercase() == attr.value.to_lowercase())) ==
                             Some(true);
                     if !whitelisted {
                         // If the class attribute is not whitelisted,
@@ -2208,6 +2208,25 @@ mod test {
         assert_eq!(
             result.to_string(),
             "<p data-label=\"bar\" name=\"foo\"></p>",
+        );
+    }
+    #[test]
+    fn tag_attribute_values_case_insensitive() {
+        let fragment = "<input type=\"CHECKBOX\" name=\"foo\">";
+        let result = Builder::new()
+            .tags(hashset!["input"])
+            .tag_attribute_values(hashmap![
+                "input" => hashmap![
+                    "type" => hashset!["checkbox"],
+                ],
+            ])
+            .tag_attributes(hashmap![
+                "input" => hashset!["name"],
+            ])
+            .clean(fragment);
+        assert_eq!(
+            result.to_string(),
+            "<input type=\"CHECKBOX\" name=\"foo\">",
         );
     }
     #[test]


### PR DESCRIPTION
See #100.

- [x] The doctests seem convoluted. If you have any suggestions, I'd be happy to update them.
  - The `rm_tag_attribute_values` doctest is particularly bad.
- [x] I don't see a reason for there to be defaults for the tag attribute values. Should there be any?
- [x] Should values be case-insensitive?
- [x] I didn't see any performance regression in the benchmarks.
- [x] All original and all newly-added tests pass.

Let me know if anything catches your eye that should be changed! :)